### PR TITLE
FEATURE: CreativeDetailページに2カラムレイアウトを実装、アニメーション改善

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -293,10 +293,10 @@
     opacity: 0;
   }
   .slide-enter-active {
-    animation: slide-in .2s cubic-bezier(0,.94,.57,1.02);
+    animation: slide-in .5s cubic-bezier(0.25, 0.1, 0.25, 1);
   }
   .slide-leave-active {
-    animation: slide-out .2s cubic-bezier(0,.94,.57,1.02);
+    animation: slide-out .4s cubic-bezier(0.4, 0, 1, 1);
   }
 
   @keyframes slide-in {

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -218,6 +218,7 @@ export default {
   position: relative;
   z-index: 11;
   pointer-events: auto !important;
+  white-space: nowrap;
 }
 
 .nav-link:hover {

--- a/src/main.js
+++ b/src/main.js
@@ -6,16 +6,17 @@ import { createHead } from '@vueuse/head'
 
 // FontAwesomeを必要なものだけに絞り込み
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { 
-  faArrowUpRightFromSquare, 
-  faArrowRight, 
-  faFilm, 
-  faCode, 
-  faPalette, 
-  faVideo, 
-  faPlay, 
+import {
+  faArrowUpRightFromSquare,
+  faArrowRight,
+  faArrowLeft,
+  faFilm,
+  faCode,
+  faPalette,
+  faVideo,
+  faPlay,
   faGlobe,
-  faEnvelope, 
+  faEnvelope,
   faLink,
   faUsers,
   faShareNodes,
@@ -32,15 +33,16 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 // アイコンをライブラリに追加
 library.add(
-  faLink, 
-  faEnvelope, 
-  faGithub, 
-  faTwitter, 
-  faLinkedin, 
-  faInstagram, 
-  faDiscord, 
-  faArrowUpRightFromSquare, 
+  faLink,
+  faEnvelope,
+  faGithub,
+  faTwitter,
+  faLinkedin,
+  faInstagram,
+  faDiscord,
+  faArrowUpRightFromSquare,
   faArrowRight,
+  faArrowLeft,
   faFilm,
   faCode,
   faPalette,

--- a/src/views/CreativeDetail.vue
+++ b/src/views/CreativeDetail.vue
@@ -9,8 +9,19 @@
     <!-- 作品タイトル -->
     <h1 class="creative-title">{{ $t(creative.title) }}</h1>
 
-    <!-- 作品画像ギャラリー -->
-    <div class="image-gallery" v-if="detailData.images && detailData.images.length > 0">
+    <!-- タグ -->
+    <div class="creative-tags" v-if="creative.tags && creative.tags.length > 0">
+      <span v-for="(tag, index) in creative.tags" :key="index" class="creative-tag">
+        {{ tag }}
+      </span>
+    </div>
+
+    <!-- 2カラムコンテンツ -->
+    <div class="content-wrapper">
+      <!-- 左カラム: 画像・動画 -->
+      <div class="left-column">
+        <!-- 作品画像ギャラリー -->
+        <div class="image-gallery" v-if="detailData.images && detailData.images.length > 0">
       <img
         v-for="(image, index) in detailData.images"
         :key="index"
@@ -42,10 +53,13 @@
           loading="lazy"
         ></iframe>
       </div>
-    </div>
+        </div>
+      </div>
 
-    <!-- 作品説明文（Markdown対応） -->
-    <div class="creative-description" v-html="renderedDescription"></div>
+      <!-- 右カラム: 説明文・メタ情報 -->
+      <div class="right-column">
+        <!-- 作品説明文（Markdown対応） -->
+        <div class="creative-description" v-html="renderedDescription"></div>
 
     <!-- 制作年 -->
     <div v-if="detailData.productionYear" class="production-year">
@@ -61,14 +75,8 @@
           <dd class="credit-value">{{ credit.value }}</dd>
         </template>
       </dl>
-    </div>
-
-    <!-- タグ -->
-    <div class="creative-tags" v-if="creative.tags && creative.tags.length > 0">
-      <strong>{{ $t('creatives.common.tags') }}:</strong>
-      <span v-for="(tag, index) in creative.tags" :key="index" class="creative-tag">
-        {{ tag }}
-      </span>
+        </div>
+      </div>
     </div>
 
     <!-- CTA ボタン -->
@@ -269,15 +277,7 @@
   .creative-detail {
     max-width: 900px;
     margin: 0 auto;
-    padding: 2.5rem 2rem;
-    background: rgba(255, 255, 255, 0.18);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    border-right-color: rgba(255, 255, 255, 0.2);
-    border-bottom-color: rgba(255, 255, 255, 0.2);
-    border-radius: 18px;
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+    padding: 2.5rem 2rem 5rem 2rem;
     color: var(--color-text, #111);
   }
 
@@ -299,19 +299,33 @@
   }
 
   .creative-title {
-    font-size: 2rem;
-    font-weight: 700;
-    margin-bottom: 1.8rem;
-    letter-spacing: 0.01em;
+    font-size: 1.9rem;
+    font-weight: 600;
+    margin-bottom: 0;
+    letter-spacing: 0;
     color: var(--color-text, #111);
-    border-bottom: 2px solid rgba(240, 211, 0, 0.35);
-    padding-bottom: 0.6rem;
+  }
+
+  .content-wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2.5rem;
+    margin-bottom: 2.5rem;
+    align-items: start;
+  }
+
+  .left-column {
+    /* 画像・動画エリア */
+  }
+
+  .right-column {
+    /* 説明文・メタ情報エリア */
   }
 
   .image-gallery {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.25rem;
+    grid-template-columns: 1fr;
+    gap: 1rem;
     margin-bottom: 2rem;
   }
 
@@ -319,25 +333,18 @@
     width: 100%;
     height: auto;
     border-radius: 0.5rem;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.4);
-    background: #fff;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   }
 
   .youtube-section {
-    margin-bottom: 1.75rem;
-    padding: 1.25rem 1.5rem;
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-radius: 14px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+    margin-bottom: 2rem;
   }
 
   .youtube-section h2 {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: 1.4rem;
+    font-weight: 600;
     margin-bottom: 1rem;
-    color: #333;
+    color: #222;
   }
 
   .video-container {
@@ -359,35 +366,28 @@
   }
 
   .creative-description {
-    font-size: 1rem;
-    line-height: 1.8;
-    margin-bottom: 1.75rem;
-    padding: 1.25rem 1.5rem;
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-radius: 14px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+    font-size: 1.05rem;
+    line-height: 2;
+    margin-bottom: 2rem;
     color: var(--color-text, #111);
   }
 
   .creative-description :deep(h2) {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin: 1.5rem 0 1rem;
+    font-size: 1.35rem;
+    font-weight: 600;
+    margin: 2rem 0 1rem;
     color: var(--color-text, #111);
-    border-left: 4px solid var(--manapuraza-yellow, #f0d300);
-    padding-left: 0.75rem;
   }
 
   .creative-description :deep(h3) {
-    font-size: 1.3rem;
-    font-weight: 600;
-    margin: 1.2rem 0 0.8rem;
-    color: #222;
+    font-size: 1.2rem;
+    font-weight: 500;
+    margin: 1.5rem 0 0.8rem;
+    color: #111;
   }
 
   .creative-description :deep(p) {
-    margin-bottom: 1rem;
+    margin-bottom: 1.2rem;
   }
 
   .creative-description :deep(ul),
@@ -414,44 +414,29 @@
   }
 
   .production-year {
-    font-size: 1rem;
-    margin-bottom: 1.5rem;
-    color: #333;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 1rem;
-    background: rgba(240, 211, 0, 0.18);
-    border: 1px solid rgba(240, 211, 0, 0.4);
-    border-radius: 999px;
-    font-weight: 600;
+    font-size: 0.95rem;
+    margin-bottom: 2rem;
+    color: #555;
+    font-weight: 500;
   }
 
   .credits-section {
-    margin-bottom: 1.75rem;
-    padding: 1.25rem 1.5rem;
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-radius: 14px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+    margin-bottom: 2rem;
   }
 
   .credits-section h2 {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: 1.4rem;
+    font-weight: 600;
     margin-bottom: 1rem;
-    color: #333;
+    color: #222;
   }
 
   .credits-grid {
     display: grid;
     grid-template-columns: 160px 1fr;
     column-gap: 1rem;
-    row-gap: 0.5rem;
+    row-gap: 0.75rem;
     margin: 0;
-    background: rgba(240, 211, 0, 0.05);
-    padding: 1rem;
-    border-radius: 0.5rem;
   }
 
   .credit-label {
@@ -471,48 +456,45 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 1.75rem;
-    padding: 1.1rem 1.3rem;
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-radius: 14px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
-  }
-
-  .creative-tags strong {
-    font-weight: 700;
-    color: var(--color-text, #111);
+    gap: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 2rem;
   }
 
   .creative-tag {
     display: inline-block;
-    padding: 0.35rem 0.8rem;
-    background: rgba(240, 211, 0, 0.15);
-    border: 1.5px solid rgba(240, 211, 0, 0.4);
-    border-radius: 12px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: #333;
-    transition: all 0.3s ease;
+    padding: 0.4rem 0.9rem;
+    background: rgba(240, 211, 0, 0.12);
+    border: 1px solid rgba(240, 211, 0, 0.3);
+    border-radius: 8px;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #444;
+    transition: all 0.2s ease;
   }
 
   .creative-tag:hover {
-    background: rgba(240, 211, 0, 0.25);
-    border-color: rgba(240, 211, 0, 0.6);
+    background: rgba(240, 211, 0, 0.2);
+    border-color: rgba(240, 211, 0, 0.45);
     transform: translateY(-1px);
   }
 
   .cta-section {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: 1rem;
-    margin-top: 1.25rem;
-    padding: 1.25rem 1.5rem;
-    background: rgba(255, 255, 255, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.6);
-    border-radius: 14px;
-    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+    padding: 1rem 1.5rem;
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+    z-index: 100;
   }
 
   .cta-section > * {
@@ -536,11 +518,24 @@
 
   @media screen and (max-width: 768px) {
     .creative-detail {
-      padding: 2rem 1.25rem;
+      padding: 2rem 1.25rem 5rem 1.25rem;
+    }
+
+    .content-wrapper {
+      grid-template-columns: 1fr;
+      gap: 2rem;
     }
 
     .creative-title {
-      font-size: 1.5rem;
+      font-size: 1.4rem;
+    }
+
+    .creative-tags {
+      margin-bottom: 1.5rem;
+    }
+
+    .image-gallery {
+      grid-template-columns: 1fr;
     }
 
     .credits-grid {
@@ -552,26 +547,42 @@
     }
 
     .cta-section {
+      padding: 0.75rem 1rem;
       flex-direction: column;
     }
 
     .cta-section > * {
+      width: 100%;
       min-width: auto;
     }
   }
 
   @media screen and (max-width: 480px) {
     .creative-detail {
-      padding: 1.5rem 1rem;
+      padding: 1.5rem 1rem 5rem 1rem;
     }
 
     .creative-title {
-      font-size: 1.3rem;
+      font-size: 1.25rem;
+    }
+
+    .creative-tags {
+      margin-bottom: 1rem;
+      gap: 0.5rem;
+    }
+
+    .creative-tag {
+      font-size: 0.7rem;
+      padding: 0.3rem 0.7rem;
     }
 
     .creative-description {
-      font-size: 0.95rem;
-      line-height: 1.6;
+      font-size: 1rem;
+      line-height: 1.8;
+    }
+
+    .cta-section {
+      padding: 0.5rem 0.75rem;
     }
   }
 </style>


### PR DESCRIPTION
- CreativeDetailページをデスクトップで2カラムGrid実装（左: 画像、右: 説明文）
- タグをタイトル直下に移動、ラベルを削除
- 画像ギャラリーを単一列に最適化
- レスポンシブ対応（768px以下で単一カラム切り替え）
- FontAwesomeにfaArrowLeftアイコンを追加（戻るリンク用）
- Menu.vueの.nav-linkにwhite-space: nowrapを付与
- App.vueのページ遷移アニメーションを改善（transform: 2%、duration: 0.5s/0.4s）

🤖 Generated with [Claude Code](https://claude.com/claude-code)